### PR TITLE
new event constructor 

### DIFF
--- a/eventstore.go
+++ b/eventstore.go
@@ -107,7 +107,7 @@ func NewEventMetadata(metadata map[string]string) NewEventOption {
 	}
 }
 
-func (s *EventStore) NewEvent(data any, opts ...NewEventOption) (*Event, error) {
+func NewEvent(data any, opts ...NewEventOption) (*Event, error) {
 	// Create a new event with the data provided.
 	e := &Event{
 		ID:   nuid.New().Next(),

--- a/eventstore_test.go
+++ b/eventstore_test.go
@@ -57,7 +57,7 @@ func TestNewEventConstructor(t *testing.T) {
 	metadata := map[string]string{"foo": "bar"}
 
 	// Test with a valid type.
-	e, err := es.NewEvent(&OrderPlaced{ID: "123"},
+	e, err := NewEvent(&OrderPlaced{ID: "123"},
 		NewEventID("abc123"),
 		NewEventType("placed-order"),
 		NewEventTime(eventTime),


### PR DESCRIPTION
Primary driver behind this is that the Event has a few `read_only` fields that are still able to be set when you build the event manually