### PR TITLE
Add Getting Started README and docs/ with runnable pattern examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,80 @@ go get github.com/synadia-labs/rita
 
 ## Getting Started
 
-Coming soon!
+Rita persists your application's **events** to a JetStream stream and gives you
+the tools to turn those events back into **state**. You write small models that
+either *decide* what events a command produces or *evolve* state from events;
+Rita handles serialization, storage, ordering, concurrency, and delivery.
+
+You need a NATS server with JetStream enabled:
+
+```bash
+nats-server -js
+```
+
+Given two event types, `OrderPlaced` and `OrderShipped`, a **model** folds them
+into state by implementing `Evolve`:
+
+```go
+type Order struct {
+	Placed  bool
+	Shipped bool
+	Amount  int
+}
+
+func (o *Order) Evolve(_ context.Context, e *rita.Event) error {
+	switch d := e.Data.(type) {
+	case *OrderPlaced:
+		o.Placed, o.Amount = true, d.Amount
+	case *OrderShipped:
+		o.Shipped = true
+	}
+	return nil
+}
+```
+
+Append events for an entity (identified as `<type>.<id>`), then rebuild its
+state by replaying them through the model:
+
+```go
+es.Append(ctx, []*rita.Event{
+	{Entity: "order.1001", Data: &OrderPlaced{OrderID: "1001", Amount: 50}},
+	{Entity: "order.1001", Data: &OrderShipped{OrderID: "1001", Carrier: "UPS"}},
+})
+
+var order Order
+es.Evolve(ctx, &order, rita.WithFilters("order.1001"))
+// order.Placed == true, order.Shipped == true, order.Amount == 50
+```
+
+> **Full runnable example** — with the embedded server, registry, and error
+> handling: [`examples/quickstart/main.go`](./examples/quickstart/main.go). The
+> event types and model are lines 21–47; appending and rebuilding state is lines
+> 93–107.
+
+## Examples
+
+Each pattern has a complete, runnable program under [`examples/`](./examples):
+
+| Example | Pattern |
+| --- | --- |
+| [`quickstart`](./examples/quickstart) | Append events and rebuild state. |
+| [`deciders`](./examples/deciders) | Command → events → state through a model. |
+| [`optimistic-concurrency`](./examples/optimistic-concurrency) | Expected-sequence guarding and retry. |
+| [`projection`](./examples/projection) | A live read model via `Watch`. |
+| [`tenancy`](./examples/tenancy) | One store, many isolated tenants. |
+| [`reactor`](./examples/reactor) | A minimal durable side-effect consumer. |
+| [`reactor-lifecycle`](./examples/reactor-lifecycle) | The full reactor management API. |
+
+## Documentation
+
+The [`docs/`](./docs) directory breaks down each pattern in depth:
+
+- [Concepts & architecture](./docs/README.md) — new to event sourcing? Start here: how to think in events, then how Rita's pieces fit and its subject layout.
+- [Event stores](./docs/event-stores.md) — the manager and event store lifecycle.
+- [Events & types](./docs/events-and-types.md) — events, entities, the type registry, and codecs.
+- [Deciders & evolvers](./docs/deciders-and-evolvers.md) — the core write-side patterns and optimistic concurrency.
+- [Reading state](./docs/reading-state.md) — `Evolve`, `Watch`, filters, and sequence windows.
+- [Reactors](./docs/reactors.md) — durable consumers for side effects.
+- [Multi-tenancy](./docs/tenancy.md) — scoping a single store to many tenants.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -162,5 +162,5 @@ names.
 | **Viewer** | Read-only access to a model's state. |
 | **Model[T]** | Thread-safe combinator of Decider/Evolver/Viewer with sequence tracking. |
 | **Reactor** | A durable consumer that runs side effects per event. |
-| **Type registry** | Maps event/command type names to Go structs and a codec. |
+| **Type registry** | Maps event type names to Go structs and a codec. |
 | **Tenant** | An isolated subject scope within a single tenant-enabled store. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,9 +78,9 @@ Rita has a small surface area built around a few collaborating pieces.
                        └──────────┘            └─────┬──────┘          └──────────┘
                                                      │
                                        Watch ────────┤──────── Reactor
-                                  (in-process views)  │   (durable side effects)
-                                                      ▼
-                                                external systems
+                                  (in-process views) │   (durable side effects)
+                                                     ▼
+                                             external systems
 ```
 
 - A [**Manager**](./event-stores.md) holds shared dependencies (a type

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,166 @@
+# Rita Documentation
+
+Rita is a library for building **event-sourced** applications on top of NATS
+JetStream. Before reaching for the API, it's worth slowing down on the idea
+underneath it — the patterns here land a lot more naturally once the concept
+clicks.
+
+## Thinking in events
+
+Picture a bank account. The balance you see isn't really the truth of the
+account; it's a summary. The truth is the ledger underneath it — *deposited
+$50*, *withdrew $20*, *deposited $100* — and the balance is just what you get
+when you add those up. Hand someone only the final number and throw the ledger
+away, and you've lost something you can't get back: not just the history, but
+the reason behind every change.
+
+Most software does exactly that. A row in a table holds the current state, and
+each update overwrites what was there a moment ago. The previous value, and the
+intent behind the change, are gone the instant the new value lands.
+
+Event sourcing turns this inside out. You store the **events** — the things that
+happened — and treat them as the source of truth. State is no longer something
+you keep; it's something you *derive* by replaying events, the same way a
+balance is derived from a ledger. An event is final: it can be read and
+interpreted a dozen ways downstream, but the fact that it happened is not up for
+debate.
+
+Three words recur throughout these docs, and they're worth pinning down:
+
+- An **event** is something that *already happened* — `order-placed`,
+  `order-shipped`. Past tense, and indisputable.
+- A **command** is an *intention to do something* — `place-order`, `ship-order`.
+  Imperative, and — unlike an event — a command can be refused.
+- **State** is the point-in-time information you need in order to evaluate the
+  next command.
+
+How they fit together is the whole idea: **as events occur, you derive the state
+needed to evaluate the next command, and honoring that command produces new
+events.** And it only ever flows one way — you can always rebuild state from the
+log, but you can never rebuild the log from state. So Rita keeps the one thing
+you can't recompute (the events) and lets you recompute everything else (your
+read models, your views, your projections) whenever you need it.
+
+## Why NATS
+
+None of this requires NATS, but NATS fits unusually well. JetStream is a
+messaging-first system where durable, ordered, append-only streams aren't a
+feature bolted on the side — they're the substrate. An event store really only
+needs four things, and JetStream offers each of them natively: streams that
+persist indefinitely, subjects that key granular sequences of events, an
+expected-sequence check for [optimistic
+concurrency](./deciders-and-evolvers.md#optimistic-concurrency), and consumers
+for replaying a stream or following it live. Rita is a thin layer that maps
+event sourcing onto those primitives, so you can think in events instead of in
+streams and consumers.
+
+This directory documents the patterns Rita provides for doing that well.
+
+## Contents
+
+- [Architecture overview](#architecture-overview) (this page)
+- [Event stores](./event-stores.md) — the manager and the event store lifecycle.
+- [Events & types](./events-and-types.md) — events, entities, the type registry, and codecs.
+- [Deciders & evolvers](./deciders-and-evolvers.md) — the core write-side patterns and optimistic concurrency.
+- [Reading state](./reading-state.md) — `Evolve`, `Watch`, filters, and sequence windows.
+- [Reactors](./reactors.md) — durable consumers for side effects.
+- [Multi-tenancy](./tenancy.md) — scoping a single store to many tenants.
+
+## Architecture overview
+
+Rita has a small surface area built around a few collaborating pieces.
+
+```
+  Command                Events                  Stream                  State
+ ┌─────────┐  Decide   ┌──────────┐   Append   ┌────────────┐  Evolve  ┌──────────┐
+ │ Command │ ────────► │ Decider  │ ─────────► │ EventStore │ ───────► │ Evolver  │
+ └─────────┘           │ (model)  │            │ (JetStream)│          │ (model)  │
+                       └──────────┘            └─────┬──────┘          └──────────┘
+                                                     │
+                                       Watch ────────┤──────── Reactor
+                                  (in-process views)  │   (durable side effects)
+                                                      ▼
+                                                external systems
+```
+
+- A [**Manager**](./event-stores.md) holds shared dependencies (a type
+  registry, an ID generator, a clock, a logger) and creates **EventStores**.
+- An [**EventStore**](./event-stores.md) is backed by exactly one JetStream
+  stream. It is where you `Append` events and from which you `Evolve` or
+  `Watch` to rebuild state.
+- An [**Event**](./events-and-types.md) is an immutable fact about an
+  **entity**. Events are the source of truth.
+- A [**Decider**](./deciders-and-evolvers.md) turns a **Command** (a request to
+  change something) into zero or more events.
+- An [**Evolver**](./deciders-and-evolvers.md) folds events into in-memory
+  **state**. A **Viewer** reads that state. The generic
+  [`Model[T]`](./deciders-and-evolvers.md#model) combines all three with
+  thread-safety and per-entity sequence tracking.
+- A [**Reactor**](./reactors.md) is a durable consumer that runs side effects
+  (send an email, call an API) as events arrive.
+
+The write side (commands → events) and the read side (events → state) are
+deliberately separate. Events are the contract between them.
+
+## The CQRS / event-sourcing flow
+
+A typical request flows through Rita like this:
+
+1. A command arrives (`PlaceOrder`).
+2. A **Decider** validates it against current state and emits events
+   (`OrderPlaced`).
+3. Rita **Appends** those events to the stream — atomically, and optionally
+   guarded by an [expected sequence](./deciders-and-evolvers.md#optimistic-concurrency)
+   for optimistic concurrency.
+4. Read models rebuild state by **Evolving** over the events, either on demand
+   (`Evolve`) or continuously (`Watch`).
+5. **Reactors** independently observe the same events to trigger side effects,
+   durably and at-least-once.
+
+Steps 2–3 are the write side; steps 4–5 are the read side. They only ever
+communicate through stored events.
+
+## Subject & storage layout
+
+Every event store maps to one JetStream stream and a hierarchical subject space.
+Understanding the layout makes the [filtering](./reading-state.md#filters) rules
+intuitive.
+
+| Concept | Pattern | Example |
+| --- | --- | --- |
+| Stream name | `ES_<name>` | `ES_orders` |
+| Stream subjects | `$ES.<name>.>` | `$ES.orders.>` |
+| Event subject | `$ES.<name>.<entity-type>.<entity-id>.<event-type>` | `$ES.orders.order.1001.order-shipped` |
+| Tenant event subject | `$ES.<name>.<tenant>.<entity-type>.<entity-id>.<event-type>` | `$ES.orders.acme.order.1001.order-shipped` |
+
+The three trailing tokens — `<entity-type>.<entity-id>.<event-type>` — are what
+you match against with [filters](./reading-state.md#filters). The
+[`Entity`](./events-and-types.md#entities) field supplies the first two; the
+event type supplies the third.
+
+Each event is stored as a single JetStream message:
+
+- The encoded event **data** is the message body.
+- The event **envelope** (id, entity, type, time, codec, custom metadata) is
+  stored in NATS message **headers**, which lets consumers fetch headers without
+  the body when that is all they need.
+
+See [Events & types](./events-and-types.md#on-the-wire) for the exact header
+names.
+
+## Glossary
+
+| Term | Meaning |
+| --- | --- |
+| **Manager** | Factory for event stores; carries shared registry/clock/id/logger. |
+| **EventStore** | A JetStream-backed log of events plus operations over it. |
+| **Event** | An immutable fact about an entity; the unit of storage. |
+| **Entity** | The thing an event is about, identified as `<type>.<id>` (e.g. `order.1001`). |
+| **Command** | A request to change state; input to a Decider. |
+| **Decider** | `Decide(cmd) -> events`. The write-side decision logic. |
+| **Evolver** | `Evolve(event)` mutating in-memory state. The read-side fold. |
+| **Viewer** | Read-only access to a model's state. |
+| **Model[T]** | Thread-safe combinator of Decider/Evolver/Viewer with sequence tracking. |
+| **Reactor** | A durable consumer that runs side effects per event. |
+| **Type registry** | Maps event/command type names to Go structs and a codec. |
+| **Tenant** | An isolated subject scope within a single tenant-enabled store. |

--- a/docs/deciders-and-evolvers.md
+++ b/docs/deciders-and-evolvers.md
@@ -80,6 +80,11 @@ cannot fail.
 
 ## Append
 
+`Append`, `Decide`, and `DecideAndEvolve` below are methods on the `EventStore` —
+the store's write side. They orchestrate the model you defined above (calling its
+`Decider.Decide` and `Evolver.Evolve`), so note the overlapping names:
+`EventStore.Decide` is a store method, distinct from your model's `Decider.Decide`.
+
 The lowest-level write is `Append`. It validates and enriches each event (see
 [the event](./events-and-types.md#the-event)), publishes them, and returns the
 stream sequence of the last one:
@@ -98,8 +103,8 @@ slice returns `ErrNoEvents`.
 
 ## Decide
 
-`Decide` is a convenience that runs a model's `Decide` and then `Append`s the
-resulting events in one call:
+`EventStore.Decide` is a convenience that runs your model's `Decider.Decide` and
+then `Append`s the resulting events in one call:
 
 ```go
 events, seq, err := es.Decide(ctx, model, &rita.Command{Data: &PlaceOrder{}})

--- a/docs/deciders-and-evolvers.md
+++ b/docs/deciders-and-evolvers.md
@@ -68,14 +68,16 @@ type Command struct {
 	ID   string
 	Time time.Time
 	Type string
-	Data any               // a registered type, or []byte
+	Data any               // your command payload
 	Meta map[string]string
 }
 ```
 
-Commands and events share the same [type registry](./events-and-types.md#the-type-registry).
-The crucial distinction is intent: a command is a request ("place this order")
-that may fail; an event is a fact ("order was placed") that already happened and
+Unlike an event, a command is never serialized: `EventStore.Decide` hands the
+`*Command` straight to your model, so its payload type does not need to be
+registered in the [type registry](./events-and-types.md#the-type-registry). The
+crucial distinction is intent: a command is a request ("place this order") that
+may fail; an event is a fact ("order was placed") that already happened and
 cannot fail.
 
 ## Append

--- a/docs/deciders-and-evolvers.md
+++ b/docs/deciders-and-evolvers.md
@@ -1,0 +1,219 @@
+# Deciders & Evolvers
+
+This is the heart of event sourcing in Rita. State changes are expressed as two
+small, pure-ish functions:
+
+- A **Decider** answers *"given this command and the current state, what events
+  should happen?"*
+- An **Evolver** answers *"given this event, how does the state change?"*
+
+Everything else — appending, replaying, concurrency control — is built on these
+two ideas. The pattern comes from
+[functional event sourcing](https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider):
+small folds you can test in isolation, with the infrastructure kept at the edges.
+
+## The interfaces
+
+```go
+type Decider interface {
+	Decide(context.Context, *Command) ([]*Event, error)
+}
+
+type Evolver interface {
+	Evolve(context.Context, *Event) error
+}
+
+type Viewer[T any] interface {
+	View(context.Context, func(T) error) error
+}
+```
+
+A model usually implements both `Decide` and `Evolve` on the same struct, so the
+state it folds up is exactly the state its decisions are validated against. The
+decision logic is the meaningful part:
+
+```go
+// Decide turns a command into events, validating against current state.
+func (o *Order) Decide(_ context.Context, cmd *rita.Command) ([]*rita.Event, error) {
+	switch c := cmd.Data.(type) {
+	case *PlaceOrder:
+		if o.Placed {
+			return nil, errors.New("order already placed")
+		}
+		return []*rita.Event{{Entity: "order.1", Data: &OrderPlaced{Amount: c.Amount}}}, nil
+	case *ShipOrder:
+		if !o.Placed {
+			return nil, errors.New("cannot ship an order that was never placed")
+		}
+		return []*rita.Event{{Entity: "order.1", Data: &OrderShipped{Carrier: c.Carrier}}}, nil
+	}
+	return nil, nil
+}
+```
+
+Returning no events (`nil, nil`) is valid — the command was a no-op against
+current state.
+
+> **Full example:** the `Order` aggregate, with both `Decide` and `Evolve` on one
+> struct, is [`examples/deciders/main.go`](../examples/deciders/main.go), lines
+> 31–66.
+
+## Commands
+
+A `Command` is the input to a Decider: a request to change something, which may
+be accepted or rejected. It mirrors `Event` but is never stored:
+
+```go
+type Command struct {
+	ID   string
+	Time time.Time
+	Type string
+	Data any               // a registered type, or []byte
+	Meta map[string]string
+}
+```
+
+Commands and events share the same [type registry](./events-and-types.md#the-type-registry).
+The crucial distinction is intent: a command is a request ("place this order")
+that may fail; an event is a fact ("order was placed") that already happened and
+cannot fail.
+
+## Append
+
+The lowest-level write is `Append`. It validates and enriches each event (see
+[the event](./events-and-types.md#the-event)), publishes them, and returns the
+stream sequence of the last one:
+
+```go
+seq, err := es.Append(ctx, []*rita.Event{
+	{Entity: "order.1001", Data: &OrderPlaced{OrderID: "1001"}},
+	{Entity: "order.1001", Data: &OrderShipped{OrderID: "1001"}},
+})
+```
+
+A single event is published directly. **Multiple events are published as one
+atomic batch** — either all of them are stored or none are — which lets a single
+`Decide` emit several events without risk of a partial write. Appending an empty
+slice returns `ErrNoEvents`.
+
+## Decide
+
+`Decide` is a convenience that runs a model's `Decide` and then `Append`s the
+resulting events in one call:
+
+```go
+events, seq, err := es.Decide(ctx, model, &rita.Command{Data: &PlaceOrder{}})
+```
+
+It is exactly `model.Decide(...)` followed by `es.Append(...)`, with the errors
+threaded through. Use it when the deciding model and the stored events are the
+only things you need.
+
+## DecideAndEvolve
+
+`DecideAndEvolve` goes one step further: decide, append, **and** apply the new
+events back to the in-memory model so it reflects the write immediately:
+
+```go
+model := rita.NewModel(&Order{})
+
+events, seq, err := es.DecideAndEvolve(ctx, model, &rita.Command{Data: &PlaceOrder{}})
+// model now reflects OrderPlaced; no replay needed.
+```
+
+This is the workhorse for a command handler that keeps a model in memory across
+requests: each command advances both the stored log and the live model in lock
+step.
+
+> **Full example:** [`examples/deciders/main.go`](../examples/deciders/main.go) —
+> `NewModel` and the `DecideAndEvolve` command loop are lines 113–120, `View` is
+> 122–128, and a rejected decision is 130–134.
+
+> **Partial-failure note.** If the evolve step fails *after* the append
+> succeeded (including a context cancellation between events), the events are
+> already durably stored but the in-memory model has only advanced up to the
+> last successfully-applied event. Recover by calling
+> [`Evolve` with `WithAfterSequence`](./reading-state.md#sequence-windows) to
+> replay the remainder onto the model.
+
+## Model
+
+`Model[T]` wraps a value that implements any of `Decider`, `Evolver`, and/or
+`Viewer`, and adds two things you almost always want:
+
+```go
+model := rita.NewModel(&Order{})
+```
+
+**1. Thread-safety.** A bare model is fine for synchronous `Decide`/`Evolve`,
+but a [`Watch`](./reading-state.md#watch) applies events from a background
+goroutine while your request handlers read state. `Model[T]` guards all access
+with a read/write mutex, so a watched model can be safely read concurrently via
+`View`:
+
+```go
+err := model.View(ctx, func(o *Order) error {
+	fmt.Println("shipped:", o.Shipped)
+	return nil
+})
+```
+
+**2. Per-entity sequence tracking**, which buys two behaviors:
+
+- **Idempotent evolves.** The model records the last sequence applied per
+  entity and skips any event whose sequence it has already seen, so replaying or
+  overlapping a live watch with a catch-up cannot double-count.
+- **Automatic optimistic concurrency.** On `Decide`, the model stamps each
+  emitted event's `Expect` with the last sequence it has observed for that
+  entity (unless you set `Expect` yourself) — see below.
+
+`NewModel` detects which interfaces the wrapped type implements; calling a method
+the type doesn't support returns `ErrDeciderNotImplemented` or
+`ErrEvolverNotImplemented`.
+
+## Optimistic concurrency
+
+When two writers act on the same entity concurrently, you want the second write
+to fail rather than clobber the first. Rita expresses this with an expected
+sequence on the event:
+
+```go
+// Reject the append unless the entity's last event is at sequence 7.
+{Entity: "order.1001", Data: &OrderShipped{}, Expect: rita.ExpectSequence(7)}
+```
+
+On a mismatch, `Append` returns `ErrSequenceConflict`; the caller re-reads
+current state and retries. Under the hood this maps to JetStream's
+expected-last-subject-sequence check.
+
+There are two constructors:
+
+| Constructor | Guards against |
+| --- | --- |
+| `ExpectSequence(seq)` | Concurrent writes to **this entity** (the default scope: all event types for the entity). |
+| `ExpectSequenceSubject(seq, pattern)` | A custom subject scope, e.g. a single event type or an entity-type-wide stream. |
+
+When you drive writes through a [`Model[T]`](#model), you usually don't set
+`Expect` at all: the model fills it in from the sequence it last observed for the
+entity, so the read-decide-write cycle is concurrency-safe by construction.
+
+```go
+model := rita.NewModel(&Order{})
+es.Evolve(ctx, model, rita.WithFilters("order.1001")) // load current state + seq
+events, _, err := es.DecideAndEvolve(ctx, model, cmd) // Expect set automatically
+if errors.Is(err, rita.ErrSequenceConflict) {
+	// someone else wrote first; reload and retry
+}
+```
+
+> **Full example:** [`examples/optimistic-concurrency/main.go`](../examples/optimistic-concurrency/main.go)
+> races two writers on one entity — the conflicting append is lines 85–102, and
+> the reload-and-retry recovery is 104–116.
+
+## Choosing among Append / Decide / DecideAndEvolve
+
+| You have… | Use |
+| --- | --- |
+| Pre-built events, no decision logic | `Append` |
+| A command and a decider, and you'll rebuild read models elsewhere | `Decide` |
+| A command and a long-lived in-memory model to keep current | `DecideAndEvolve` |

--- a/docs/deciders-and-evolvers.md
+++ b/docs/deciders-and-evolvers.md
@@ -126,8 +126,8 @@ requests: each command advances both the stored log and the live model in lock
 step.
 
 > **Full example:** [`examples/deciders/main.go`](../examples/deciders/main.go) —
-> `NewModel` and the `DecideAndEvolve` command loop are lines 113–120, `View` is
-> 122–128, and a rejected decision is 130–134.
+> `NewModel` and the `DecideAndEvolve` command loop are lines 114–121, `View` is
+> 123–129, and a rejected decision is 131–135.
 
 > **Partial-failure note.** If the evolve step fails *after* the append
 > succeeded (including a context cancellation between events), the events are

--- a/docs/event-stores.md
+++ b/docs/event-stores.md
@@ -1,0 +1,123 @@
+# Event Stores
+
+An **event store** is a JetStream stream plus the operations Rita layers on top
+of it: appending events, replaying them into state, watching them live, and
+running reactors. You obtain event stores from a **Manager**.
+
+## The manager
+
+A `Manager` is the entry point. It holds the shared dependencies every store it
+creates will use, so they are configured once:
+
+```go
+mgr, err := rita.New(nc,
+	rita.WithRegistry(registry), // type registry (see events-and-types.md)
+	rita.WithLogger(logger),     // *slog.Logger; defaults to slog.Default()
+)
+```
+
+`New` takes an established `*nats.Conn` and a set of options:
+
+| Option | Purpose | Default |
+| --- | --- | --- |
+| `WithRegistry(*types.Registry)` | Type registry used to (de)serialize event data. | none — raw `[]byte` data only |
+| `WithClock(clock.Clock)` | Source of event timestamps. | `clock.Time` (wall clock) |
+| `WithIDer(id.ID)` | Generates event IDs when one is not supplied. | `id.NUID` |
+| `WithLogger(*slog.Logger)` | Logger for background errors (watchers, reactors). | `slog.Default()` |
+| `WithAPIPrefix(string)` | Custom JetStream API prefix (e.g. for a leaf/domain). | none |
+
+The clock and ID generator are injectable so tests can make event timestamps
+and IDs deterministic; the [`testutil`](../testutil) package provides fakes.
+
+> **Without a registry.** A manager created without `WithRegistry` still works,
+> but event `Data` must be raw `[]byte` and each event must set `Type`
+> explicitly. See [Events & types](./events-and-types.md#without-a-registry).
+
+## Store lifecycle
+
+### Create
+
+```go
+es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{
+	Name:     "orders",
+	Storage:  jetstream.FileStorage,
+	Replicas: 3,
+	MaxAge:   90 * 24 * time.Hour,
+})
+```
+
+`CreateEventStore` provisions the underlying stream (named `ES_orders`) and
+returns a handle. It returns an error if a stream with that name already exists.
+
+> **Full example:** constructing the manager and creating a store is
+> [`examples/quickstart/main.go`](../examples/quickstart/main.go), lines 80–91.
+
+`EventStoreConfig` maps directly onto JetStream stream settings:
+
+| Field | Notes |
+| --- | --- |
+| `Name` | Required. Becomes stream `ES_<name>` with subjects `$ES.<name>.>`. |
+| `Description` | Free-form stream description. |
+| `Metadata` | Custom stream metadata (key/value). |
+| `Replicas` | RAFT replica count. |
+| `Storage` | `jetstream.FileStorage` or `jetstream.MemoryStorage`. |
+| `Placement` | Cluster placement constraints. |
+| `RePublish` | JetStream re-publish configuration. |
+| `MaxMsgs` / `MaxAge` / `MaxBytes` | Retention limits. |
+| `Tenancy` | Create as a [tenant store](./tenancy.md). Immutable after creation. |
+
+Rita always creates the stream with `AllowAtomicPublish` and `AllowDirect`
+enabled — the former backs [atomic batch appends](./deciders-and-evolvers.md#append),
+the latter enables efficient direct reads.
+
+### Get
+
+```go
+es, err := mgr.GetEventStore(ctx, "orders")
+```
+
+`GetEventStore` returns a handle to an existing store. It verifies the stream
+exists (returning an error otherwise) and detects whether the store was created
+with [tenancy](./tenancy.md) enabled, so the returned handle enforces the right
+mode.
+
+### Update
+
+```go
+err := mgr.UpdateEventStore(ctx, rita.EventStoreConfig{
+	Name:   "orders",
+	MaxAge: 180 * 24 * time.Hour,
+})
+```
+
+`UpdateEventStore` reconfigures the stream. Two behaviors are worth knowing:
+
+- **Tenancy is immutable.** The existing stream's tenancy mode is preserved
+  regardless of `config.Tenancy`, so an update that forgets to set the flag
+  cannot silently demote a tenant store.
+- **Metadata is merged, not replaced.** Keys present in `config.Metadata` are
+  written (overriding any prior value); keys you omit are preserved. Removing a
+  metadata key is therefore not expressible through `Update` today.
+
+### Delete
+
+```go
+err := mgr.DeleteEventStore(ctx, "orders")
+```
+
+Deletes the stream and everything in it. This is irreversible.
+
+## What you do with a store
+
+Once you hold an `*EventStore`, the rest of Rita's API hangs off it:
+
+| Operation | Doc |
+| --- | --- |
+| `Append` events | [Deciders & evolvers](./deciders-and-evolvers.md#append) |
+| `Decide` / `DecideAndEvolve` | [Deciders & evolvers](./deciders-and-evolvers.md) |
+| `Evolve` state on demand | [Reading state](./reading-state.md#evolve) |
+| `Watch` events live | [Reading state](./reading-state.md#watch) |
+| Reactor management (`CreateReactor`, …) | [Reactors](./reactors.md) |
+| `Tenant` scoping | [Multi-tenancy](./tenancy.md) |
+
+A store handle is cheap and safe to share across goroutines.

--- a/docs/events-and-types.md
+++ b/docs/events-and-types.md
@@ -91,8 +91,9 @@ optional dotted segments). `NewRegistry` validates every type up front — that
 `Init` returns a non-nil pointer to a struct and that a value round-trips
 through the codec — so misconfiguration fails at startup, not at runtime.
 
-The same registry is used for both [commands](./deciders-and-evolvers.md#commands)
-and events.
+The registry serializes events; command payload types do not need to be
+registered, since [commands](./deciders-and-evolvers.md#commands) are never
+serialized.
 
 ### Validation
 

--- a/docs/events-and-types.md
+++ b/docs/events-and-types.md
@@ -109,6 +109,12 @@ func (o *OrderPlaced) Validate() error {
 }
 ```
 
+`Validate()` runs on the write path only, when the codec marshals an event during
+`Append`. Commands are never serialized — `EventStore.Decide` hands the
+`*Command` straight to your model — so a command type's `Validate()` is **not**
+called automatically. Validate a command inside your `Decide` method (or before
+calling it) if you need that check.
+
 ## Codecs
 
 Rita ships four codecs, registered by name in the [`codec`](../codec) package:

--- a/docs/events-and-types.md
+++ b/docs/events-and-types.md
@@ -1,0 +1,161 @@
+# Events & Types
+
+Events are the unit of storage in Rita and the contract between the write side
+and the read side. This page covers the anatomy of an event, how entities are
+identified, and how Rita turns your Go types into bytes on the wire.
+
+## The event
+
+```go
+type Event struct {
+	ID     string            // NATS Msg-Id, used for de-duplication
+	Entity string            // "<entity-type>.<entity-id>", e.g. "order.1001"
+	Time   time.Time         // when the event occurred
+	Type   string            // unique event name, e.g. "order-placed"
+	Data   any               // the payload (registered struct or []byte)
+	Meta   map[string]string // application-defined metadata
+	Expect *Expect           // optimistic-concurrency expectation (append only)
+}
+```
+
+When you `Append`, Rita fills in sensible defaults so you usually only set
+`Entity` and `Data`:
+
+- **`ID`** — if empty, a fresh ID is generated (NUID by default). The ID becomes
+  the NATS `Msg-Id`, so JetStream's de-duplication window will reject a second
+  append of the same ID. Set it yourself to make appends idempotent.
+- **`Type`** — if a [type registry](#the-type-registry) is configured, the type
+  name is inferred from the Go type of `Data`. Without a registry it is
+  required. If you set both, they must agree.
+- **`Time`** — defaults to the manager's clock (`time.Now()` in local time).
+
+Two fields are read-only and populated by Rita when events come back from the
+store:
+
+- **`Event.Sequence()`** — the stream sequence number of the event.
+- **`Event.Subject()`** — the full NATS subject the event was published to.
+
+### Entities
+
+Every event is *about* an entity, identified by the `Entity` field in the form
+`<entity-type>.<entity-id>` — exactly two tokens joined by a dot:
+
+```go
+{Entity: "order.1001", Data: &OrderShipped{...}}
+//        ^^^^^ ^^^^
+//        type  id
+```
+
+The two tokens become the middle of the event's subject
+(`$ES.orders.order.1001.order-shipped`), which is what gives you cheap
+[per-entity and per-type filtering](./reading-state.md#filters). Neither token
+may contain `.`, `*`, `>`, or whitespace — those are the characters that would
+let an entity inject extra subject tokens or wildcards. An entity that is empty
+or not two tokens is rejected with `ErrEventEntityRequired` /
+`ErrEventEntityInvalid`.
+
+### Metadata
+
+`Meta` carries application-defined key/value annotations — a correlation ID, the
+acting user, a trace span — that travel with the event but are not part of its
+payload. Each entry is stored as a NATS header prefixed with `Rita-Meta-` and is
+restored into `Meta` on read.
+
+## The type registry
+
+A registry maps **type names** (the strings stored on the wire) to **Go types**,
+and selects a **codec**. With a registry, you work in terms of your own structs
+and Rita handles serialization transparently.
+
+```go
+registry, err := types.NewRegistry(map[string]*types.Type{
+	"order-placed":  {Init: func() any { return &OrderPlaced{} }},
+	"order-shipped": {Init: func() any { return &OrderShipped{} }},
+}, types.Codec("json"))
+```
+
+> **Full example:** the registry, manager, and store setup is
+> [`examples/quickstart/main.go`](../examples/quickstart/main.go), lines 71–91.
+
+Each `Type` provides an `Init` function that returns a **pointer to a struct**.
+Rita uses it two ways:
+
+- On **write**, it reflects the Go type of your `Data` to look up the registered
+  name, which becomes the event `Type`.
+- On **read**, it calls `Init` to allocate a fresh value of the right type, then
+  decodes the message body into it. `Event.Data` comes back as your concrete
+  pointer type, ready for a type switch.
+
+Type names must match `^[\w-]+(\.[\w-]+)*$` (word characters and dashes, with
+optional dotted segments). `NewRegistry` validates every type up front — that
+`Init` returns a non-nil pointer to a struct and that a value round-trips
+through the codec — so misconfiguration fails at startup, not at runtime.
+
+The same registry is used for both [commands](./deciders-and-evolvers.md#commands)
+and events.
+
+### Validation
+
+If a registered type implements `Validate() error`, the codec calls it before
+marshaling. A non-nil error aborts the append, so invalid events never reach the
+store:
+
+```go
+func (o *OrderPlaced) Validate() error {
+	if o.Amount <= 0 {
+		return errors.New("amount must be positive")
+	}
+	return nil
+}
+```
+
+## Codecs
+
+Rita ships four codecs, registered by name in the [`codec`](../codec) package:
+
+| Name | Use |
+| --- | --- |
+| `json` | Default. Human-readable, broad interop. |
+| `msgpack` | Compact binary, schema-less. |
+| `protobuf` | For `proto.Message` types; compact and schema'd. |
+| `binary` | Pass-through for `[]byte` / `encoding.BinaryMarshaler`. |
+
+Select one per registry with `types.Codec("msgpack")`; the default is `json`.
+The codec name is recorded on each event (the `Rita-Codec` header) so reads
+decode with the same codec that wrote the data, even if the registry's default
+later changes.
+
+## Without a registry
+
+A registry is optional. Without one, Rita treats event data as opaque bytes:
+
+```go
+seq, err := es.Append(ctx, []*rita.Event{{
+	Entity: "order.1001",
+	Type:   "order-placed", // required: no type can be inferred
+	Data:   []byte(`{"amount":50}`),
+}})
+```
+
+In this mode `Data` must be a `[]byte` (the `binary` codec is used), `Type` is
+mandatory, and reads return `Data` as `[]byte`. This is useful when you manage
+serialization yourself or are bridging an existing wire format.
+
+## On the wire
+
+Each event becomes one JetStream message. The payload is the message body; the
+envelope is carried in headers so a consumer can request headers without the
+body when that is all it needs:
+
+| Header | Contents |
+| --- | --- |
+| `Nats-Msg-Id` | Event `ID` (drives de-duplication). |
+| `Rita-Entity` | The `<type>.<id>` entity. |
+| `Rita-Type` | Event type name. |
+| `Rita-Time` | Event time, RFC3339Nano. |
+| `Rita-Codec` | Codec used for the body. |
+| `Rita-Meta-<key>` | One header per `Meta` entry. |
+
+The subject the message is published to is
+`$ES.<store>.<entity-type>.<entity-id>.<event-type>` (see the
+[subject layout](./README.md#subject--storage-layout)).

--- a/docs/reactors.md
+++ b/docs/reactors.md
@@ -1,0 +1,173 @@
+# Reactors
+
+A **reactor** runs side effects in response to events: send a shipping
+notification, call a payment API, update an external search index. Where
+[`Watch`](./reading-state.md#watch) keeps in-process state current with no
+durability, a reactor is a **durable JetStream consumer** that processes each
+event **at least once** and survives restarts by resuming from its stored
+position.
+
+## The shape of a reactor
+
+There are two halves:
+
+1. A **durable consumer** on the stream, provisioned and managed through the
+   `*EventStore` (`CreateReactor`, `UpdateReactor`, …). This is server-side state
+   that persists independently of your process.
+2. A **`Reactor` handle**, which you `Bind` a handler to in order to start
+   dispatching events, and `Unbind` to stop.
+
+Separating the two means a reactor's *progress* lives in JetStream, while a
+*handler* is just a function in your process. Restart the process, bind again,
+and you resume where you left off.
+
+## A minimal reactor
+
+A reactor is mostly its handler — the function that decides each event's fate.
+The return value is the entire contract (detailed [below](#handler-return-semantics)):
+
+```go
+handler := func(ctx context.Context, ev *rita.Event) error {
+	shipped, ok := ev.Data.(*OrderShipped)
+	if !ok {
+		return rita.ErrUnprocessable // not for us — drop it (Term)
+	}
+	return notify(ctx, shipped) // nil -> Ack; error -> Nak (retry)
+}
+```
+
+The surrounding wiring is a few lines: provision the durable with
+`CreateOrUpdateReactor`, `Bind` the handler to start dispatching, and `Unbind`
+on shutdown.
+
+> **Full examples:** [`examples/reactor/main.go`](../examples/reactor/main.go) is
+> a complete end-to-end reactor — `CreateOrUpdateReactor` is lines 94–100, the
+> handler 84–92, `Bind` 102–104, and `Unbind` 108–110.
+> [`examples/reactor-lifecycle/main.go`](../examples/reactor-lifecycle/main.go)
+> walks the full management API.
+
+## Handler return semantics
+
+The handler's return value decides what happens to the message. This is the
+contract that gives you at-least-once delivery with explicit poison-message
+handling:
+
+| Return | Action | Meaning |
+| --- | --- | --- |
+| `nil` | **Ack** | Processed successfully; advance past it. |
+| `errors.Is(err, ErrUnprocessable)` | **Term** | This event can never be processed; drop it permanently (no redelivery). |
+| any other error | **Nak** | Transient failure; redeliver and try again. |
+
+`Term` is the right response to an event the handler should never have received
+(wrong type, structurally invalid) — retrying would loop forever. `Nak` is for
+failures that might succeed later (a downstream service is briefly down).
+
+## Retry and backoff
+
+By default a Nak'd message is redelivered immediately and indefinitely
+(`MaxDeliver: -1`). Configure `BackOff` to space out retries:
+
+```go
+es.CreateReactor(ctx, rita.ReactorConfig{
+	Name:    "shipping-notifier",
+	Filters: []string{"*.*.order-shipped"},
+	BackOff: []time.Duration{time.Second, 5 * time.Second, 30 * time.Second},
+})
+```
+
+The `BackOff` slice gives the delay per delivery attempt; the last entry repeats
+for all further attempts. Rita applies these delays to explicit Naks itself (it
+delays the Nak by the attempt's backoff), so backoff governs both handler-error
+retries and ack-timeout retries.
+
+## Configuration & defaults
+
+```go
+type ReactorConfig struct {
+	Name          string
+	Description   string
+	Metadata      map[string]string
+	Filters       []string
+	MaxAckPending int
+	MaxDeliver    int
+	AckWait       time.Duration
+	BackOff       []time.Duration
+}
+```
+
+Zero-valued knobs are replaced with Rita's defaults on every create/update, so
+an omitted field never silently inherits a surprising JetStream server default:
+
+| Field | Default | Why |
+| --- | --- | --- |
+| `MaxAckPending` | `1` | Serial delivery — one event in flight at a time, which preserves ordering for side effects. Raise it to process concurrently. |
+| `MaxDeliver` | `-1` | Unlimited redelivery. |
+| `AckWait` | `30s` | How long before an un-acked message is redelivered. |
+
+`Filters` uses the same [pattern syntax](./reading-state.md#filters) as `Evolve`
+and `Watch`.
+
+## Managing reactors
+
+All of these hang off the `*EventStore`:
+
+| Method | Purpose |
+| --- | --- |
+| `CreateReactor(cfg)` | Provision a new durable. Idempotent if the config matches; `ErrReactorExists` if a durable of that name exists with a *different* config. |
+| `UpdateReactor(cfg)` | Replace an existing durable's config. `cfg` is the complete desired state, not a patch. |
+| `CreateOrUpdateReactor(cfg)` | Provision or reconfigure unconditionally — good for declarative startup hooks. |
+| `GetReactor(name)` | An unbound handle to an existing durable. |
+| `ListReactors()` | All durable consumers on the stream. |
+| `DeleteReactor(name)` | Remove the durable consumer. |
+
+`UpdateReactor` is replace-semantics: read the current config, mutate, write it
+back.
+
+```go
+r, _ := es.GetReactor(ctx, "shipping-notifier")
+info, _ := r.Info(ctx)
+cfg := info.Config
+cfg.AckWait = 10 * time.Second
+es.UpdateReactor(ctx, cfg)
+```
+
+Updating the durable does **not** hot-reload a currently-bound reactor — runtime
+behavior such as `BackOff` is snapshotted at `Bind`. Unbind and bind again to
+pick up changes.
+
+> **Full example:** [`examples/reactor-lifecycle/main.go`](../examples/reactor-lifecycle/main.go)
+> exercises each operation in order — `CreateReactor` is lines 77–85,
+> `GetReactor`/`Info` 89–98, `UpdateReactor` 101–115, `ListReactors` 118–124, and
+> `DeleteReactor` 178–185.
+
+## Lifecycle: bind and unbind
+
+```go
+r.Bind(ctx, handler)   // start dispatching; ErrReactorAlreadyBound if already bound
+// ...
+r.Unbind(ctx)          // drain in-flight messages within ctx's deadline, then stop
+```
+
+- **`Bind`** attaches a handler and starts the consume loop. A handle can only be
+  bound once at a time.
+- **`Unbind`** drains in-flight handler work within `ctx`'s deadline, then stops
+  the consumer. The **durable persists** — a later `Bind` (on the same or a fresh
+  handle) resumes from the stored position. `Unbind` is idempotent. If the
+  deadline expires before the drain finishes, it cancels the handler context
+  (so in-flight work can abort), returns `ctx.Err()`, and can be called again to
+  wait for final shutdown.
+
+Unbinding is *not* deletion. To remove the consumer entirely, call
+`DeleteReactor`. If a reactor is still bound when its durable is deleted, the
+consume loop receives a terminal error (logged via the store's logger); you
+still call `Unbind` to release the in-process handle.
+
+## Tenancy note
+
+Reactor *mutations* (`Create`/`Update`/`CreateOrUpdate`/`Delete`) require a
+[tenant scope](./tenancy.md) on a tenant store so they build correctly scoped
+filter subjects. But durable **names share a single stream-wide namespace** —
+`GetReactor` and `ListReactors` are not tenant-filtered. If you need per-tenant
+reactor isolation, namespace the durable names yourself (e.g.
+`"<tenant>-shipping-notifier"`). See [Multi-tenancy](./tenancy.md#reactors-are-stream-global)
+for details.

--- a/docs/reactors.md
+++ b/docs/reactors.md
@@ -23,8 +23,8 @@ and you resume where you left off.
 
 ## A minimal reactor
 
-A reactor is mostly its handler — the function that decides each event's fate.
-The return value is the entire contract (detailed [below](#handler-return-semantics)):
+A reactor is mostly its handler — the function that decides what happens to each
+event. The return value is the entire contract (detailed [below](#handler-return-semantics)):
 
 ```go
 handler := func(ctx context.Context, ev *rita.Event) error {

--- a/docs/reading-state.md
+++ b/docs/reading-state.md
@@ -25,7 +25,7 @@ lastSeq, err := es.Evolve(ctx, &order, rita.WithFilters("order.1001"))
 
 It builds an ephemeral consumer, applies exactly the currently-pending events,
 then tears the consumer down. It is a one-shot, synchronous catch-up: when it
-returns, `stats` reflects every event in scope at the moment the call started.
+returns, `order` reflects every event in scope at the moment the call started.
 If nothing matches, it returns `0` and leaves the model untouched.
 
 Use `Evolve` for request/response work: load an entity's state, make a decision,
@@ -64,7 +64,7 @@ is current before the call returns.
 
 > **Full example:** [`examples/projection/main.go`](../examples/projection/main.go) —
 > the `Stats` read model is lines 25–39, starting the watch is 91–96, and reading
-> the live projection through `View` is 106–125.
+> the live projection through `View` is 106–128.
 
 Watch-specific options:
 

--- a/docs/reading-state.md
+++ b/docs/reading-state.md
@@ -1,0 +1,135 @@
+# Reading State
+
+State in an event-sourced system is derived, not stored. Rita gives you two ways
+to derive it from the log:
+
+- **`Evolve`** — replay events once, on demand, to build state up to *now*.
+- **`Watch`** — subscribe and keep a model continuously up to date as new events
+  arrive.
+
+Both apply events to an [`Evolver`](./deciders-and-evolvers.md#the-interfaces)
+and both accept the same [filters](#filters).
+
+## Evolve
+
+`Evolve` folds the matching events through your model and returns the sequence
+of the last event applied:
+
+```go
+var order Order
+lastSeq, err := es.Evolve(ctx, &order, rita.WithFilters("order.1001"))
+```
+
+> **Full example:** [`examples/quickstart/main.go`](../examples/quickstart/main.go) —
+> appending events and then rebuilding state with `Evolve` is lines 93–107.
+
+It builds an ephemeral consumer, applies exactly the currently-pending events,
+then tears the consumer down. It is a one-shot, synchronous catch-up: when it
+returns, `stats` reflects every event in scope at the moment the call started.
+If nothing matches, it returns `0` and leaves the model untouched.
+
+Use `Evolve` for request/response work: load an entity's state, make a decision,
+move on. For a model you keep in memory across requests, pair it with
+[`DecideAndEvolve`](./deciders-and-evolvers.md#decideandevolve) so each write
+advances the same in-memory state.
+
+## Watch
+
+`Watch` runs continuously. It applies all existing events (catching up first),
+then keeps applying new ones as they are appended, until you `Stop` it:
+
+```go
+model := rita.NewModel(&Stats{})
+
+w, err := es.Watch(ctx, model, rita.WithFilters("*.*.order-shipped"))
+if err != nil {
+	return err
+}
+defer w.Stop()
+```
+
+Because events are applied from a background goroutine, **the model must be
+thread-safe**. Use [`NewModel`](./deciders-and-evolvers.md#model), which guards
+state with a mutex, and read through `View`:
+
+```go
+model.View(ctx, func(s *Stats) error {
+	fmt.Println("shipped so far:", s.Shipped)
+	return nil
+})
+```
+
+By default `Watch` blocks until the initial catch-up is complete, so the model
+is current before the call returns.
+
+> **Full example:** [`examples/projection/main.go`](../examples/projection/main.go) —
+> the `Stats` read model is lines 25–39, starting the watch is 91–96, and reading
+> the live projection through `View` is 106–125.
+
+Watch-specific options:
+
+| Option | Effect |
+| --- | --- |
+| `WithNoWait()` | Return immediately without waiting for catch-up. |
+| `WithErrHandler(fn)` | Handle unpack/evolve errors yourself. Default logs via the store's logger. |
+
+The error handler signature is `func(err error, ev *Event, msg jetstream.Msg)`,
+giving you the failing event and raw message for logging or dead-lettering.
+
+`ctx` governs setup and the initial catch-up; once `Watch` returns, the
+watcher's lifetime is owned by `Stop()`, which cancels delivery and drains any
+buffered events.
+
+### Watch vs. reactors
+
+`Watch` keeps **in-process** read models current — it has no acknowledgements
+and no durability, so a restart re-reads from the beginning (or from a sequence
+you provide). When you need **durable, at-least-once** processing for side
+effects that must not be lost across restarts, use a
+[reactor](./reactors.md) instead.
+
+## Filters
+
+Both `Evolve` and `Watch` accept `WithFilters(patterns...)`. A pattern matches
+against the three trailing subject tokens —
+`<entity-type>.<entity-id>.<event-type>` — and may be given at any depth, with
+NATS wildcards (`*` for one token, `>` for the tail):
+
+| Pattern | Matches |
+| --- | --- |
+| (no filter) | Every event in the store. |
+| `order` | All events for every `order` entity. |
+| `order.1001` | All events for entity `order.1001`. |
+| `order.1001.order-shipped` | Only `order-shipped` events for that entity. |
+| `*.*.order-shipped` | `order-shipped` events across all entities. |
+
+A pattern shorter than three tokens is padded with `*`, so `order` is equivalent
+to `order.*.*`. A pattern with more than three tokens is rejected with
+`ErrSubjectTooManyTokens`. Multiple patterns are OR'd together.
+
+## Sequence windows
+
+Two options bound *which* events are replayed by `Evolve` (and `WithAfterSequence`
+also applies to `Watch`):
+
+| Option | Meaning |
+| --- | --- |
+| `WithAfterSequence(seq)` | Start *after* `seq` — replay only events newer than one you've already applied. |
+| `WithStopSequence(seq)` | Stop *at* `seq` — replay no further than that point. |
+
+`WithAfterSequence` is how you resume cheaply. If you persist a model's state
+alongside the last sequence it reflects (a snapshot), you can rebuild by loading
+the snapshot and replaying only what came after:
+
+```go
+// state + lastSeq were restored from a snapshot
+_, err := es.Evolve(ctx, &state, rita.WithAfterSequence(lastSeq))
+```
+
+It is also the documented recovery path when
+[`DecideAndEvolve` fails mid-evolve](./deciders-and-evolvers.md#decideandevolve):
+replay from the last sequence the model successfully applied.
+
+`WithStopSequence` lets you reconstruct historical state — what the entity looked
+like as of a particular point in the log — which is useful for debugging,
+auditing, or "as-of" queries.

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -1,0 +1,124 @@
+# Multi-tenancy
+
+A **tenant store** lets one event store serve many isolated tenants without a
+stream per tenant. Tenancy inserts a tenant token into every event subject, so
+each tenant's events occupy a disjoint slice of the subject space within the
+same JetStream stream.
+
+```
+ Untenanted:  $ES.orders.order.1001.order-shipped
+ Tenant:      $ES.orders.acme.order.1001.order-shipped
+                         ^^^^ tenant token
+```
+
+## Enabling tenancy
+
+Set `Tenancy` when creating the store:
+
+```go
+es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{
+	Name:    "orders",
+	Tenancy: true,
+})
+```
+
+This records a marker in the stream's metadata. **Tenancy is fixed at creation
+and immutable** — `UpdateEventStore` always preserves the existing mode, so an
+update that forgets the flag cannot silently demote a tenant store, and you
+cannot convert an untenanted store into a tenant one. `GetEventStore` reads the
+marker back, so a handle always knows whether it is tenanted.
+
+## Scoping a handle
+
+On a tenant store, the bare handle returned by `CreateEventStore`/`GetEventStore`
+is **unscoped** and cannot perform store operations. Derive a scoped handle with
+`Tenant`:
+
+```go
+acme, err := es.Tenant("acme")
+if err != nil {
+	return err
+}
+
+acme.Append(ctx, []*rita.Event{
+	{Entity: "order.1001", Data: &OrderPlaced{}},
+})
+```
+
+`Tenant` returns a derived handle and leaves the receiver unchanged, so scopes
+are immutable and cheap to derive — hand each request its own scoped handle.
+Re-scoping replaces rather than nests: `es.Tenant("a").Tenant("b")` is tenant
+`"b"`.
+
+A tenant token is a single subject token: it must be non-empty and may not
+contain `.`, `*`, `>`, or whitespace. An invalid token returns
+`ErrTenantInvalid`.
+
+> **Full example:** [`examples/tenancy/main.go`](../examples/tenancy/main.go) —
+> creating the tenant store is lines 67–68, the unscoped-handle guard
+> (`ErrTenantRequired`) is 73–79, deriving per-tenant handles is 81–90, and the
+> per-tenant read isolation is 104–115.
+
+## How scoping affects operations
+
+Every store operation enforces the rule that **a tenant store requires a tenant
+scope**:
+
+| Situation | Result |
+| --- | --- |
+| Operation on a scoped handle (`es.Tenant("acme")`) | Confined to that tenant. |
+| Operation on an unscoped handle of a tenant store | `ErrTenantRequired` |
+| `Tenant(...)` on an untenanted store | `ErrTenantNotSupported` |
+
+Scoping flows through transparently:
+
+- **Appends** publish under the tenant's subject prefix.
+- **`Evolve` / `Watch`** are confined to the tenant. A scoped handle with no
+  explicit filters defaults to the tenant-wide pattern (not the whole stream),
+  so you can never accidentally read across tenants.
+- **Filters** are still written in their normal
+  [user form](./reading-state.md#filters) (`order.1001`,
+  `*.*.order-shipped`); Rita inserts the tenant token for you. You never write
+  the tenant into a filter yourself.
+
+The untenanted code path is byte-for-byte unchanged: on a store created without
+tenancy, subjects and filters look exactly as they would without this feature.
+
+## Reactors are stream-global
+
+Tenancy scopes *subjects*, but durable consumer **names** share a single
+stream-wide namespace. This has a deliberate, sharp edge:
+
+- Reactor **mutations** (`CreateReactor`, `UpdateReactor`,
+  `CreateOrUpdateReactor`, `DeleteReactor`) require a tenant scope, because they
+  build tenant-scoped filter subjects.
+- Reactor **lookups** (`GetReactor`, `ListReactors`) are **not** tenant-filtered.
+  `ListReactors` on a tenant store returns durables created under every tenant.
+
+Because the lookup is stream-global, `ListReactors` decodes each durable's
+filters by stripping the *calling* handle's tenant prefix. A durable that
+belongs to the calling tenant comes back in user form
+(`*.*.order-shipped`); a durable from another tenant doesn't match the prefix
+and is surfaced verbatim
+(`$ES.orders.other-tenant.*.*.order-shipped`).
+
+**If you need per-tenant reactor isolation, namespace the durable names
+yourself**, e.g. `"acme-shipping-notifier"`:
+
+```go
+acme, _ := es.Tenant("acme")
+acme.CreateReactor(ctx, rita.ReactorConfig{
+	Name:    "acme-shipping-notifier", // tenant-prefixed name
+	Filters: []string{"*.*.order-shipped"},
+})
+```
+
+Library-side name namespacing is a possible future addition.
+
+## Choosing tenancy vs. separate stores
+
+Tenancy keeps every tenant in one stream, which means shared retention limits,
+shared replication, and a shared consumer namespace. Reach for it when tenants
+are numerous and individually small, and when uniform configuration is
+acceptable. When tenants need independent retention, placement, or per-tenant
+operational isolation, a stream (event store) per tenant is the better fit.

--- a/examples/deciders/main.go
+++ b/examples/deciders/main.go
@@ -86,9 +86,10 @@ func run() error {
 	}
 	defer nc.Close()
 
+	// Only events are registered: events are serialized to and from the log,
+	// commands never are. EventStore.Decide passes the *Command straight to the
+	// model, so registering command types would wrongly imply they are stored.
 	registry, err := types.NewRegistry(map[string]*types.Type{
-		"place-order":   {Init: func() any { return &PlaceOrder{} }},
-		"ship-order":    {Init: func() any { return &ShipOrder{} }},
 		"order-placed":  {Init: func() any { return &OrderPlaced{} }},
 		"order-shipped": {Init: func() any { return &OrderShipped{} }},
 	})

--- a/examples/deciders/main.go
+++ b/examples/deciders/main.go
@@ -1,0 +1,137 @@
+// Deciders demonstrates the write-side patterns: a model that both decides
+// (command -> events) and evolves (event -> state), driven through a thread-safe
+// Model with DecideAndEvolve, and read back through View. It also shows a
+// decision being rejected when it would violate an invariant.
+//
+// Run with: go run ./examples/deciders
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/synadia-labs/rita"
+	"github.com/synadia-labs/rita/testutil"
+	"github.com/synadia-labs/rita/types"
+)
+
+// Commands are intentions; they may be refused.
+type PlaceOrder struct{ Amount int }
+type ShipOrder struct{ Carrier string }
+
+// Events are facts; they already happened.
+type OrderPlaced struct{ Amount int }
+type OrderShipped struct{ Carrier string }
+
+// Order is an aggregate: it decides what events a command produces (validating
+// against current state) and evolves its state from those events.
+type Order struct {
+	Placed  bool
+	Shipped bool
+	Amount  int
+}
+
+func (o *Order) Decide(_ context.Context, cmd *rita.Command) ([]*rita.Event, error) {
+	switch c := cmd.Data.(type) {
+	case *PlaceOrder:
+		if o.Placed {
+			return nil, errors.New("order already placed")
+		}
+		return []*rita.Event{{Entity: "order.1", Data: &OrderPlaced{Amount: c.Amount}}}, nil
+	case *ShipOrder:
+		if !o.Placed {
+			return nil, errors.New("cannot ship an order that was never placed")
+		}
+		if o.Shipped {
+			return nil, errors.New("order already shipped")
+		}
+		return []*rita.Event{{Entity: "order.1", Data: &OrderShipped{Carrier: c.Carrier}}}, nil
+	}
+	return nil, nil
+}
+
+func (o *Order) Evolve(_ context.Context, e *rita.Event) error {
+	switch d := e.Data.(type) {
+	case *OrderPlaced:
+		o.Placed, o.Amount = true, d.Amount
+	case *OrderShipped:
+		o.Shipped = true
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	dir, err := os.MkdirTemp("", "rita-example-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	srv := testutil.NewNatsServerWithDir(dir)
+	defer testutil.ShutdownNatsServer(srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	registry, err := types.NewRegistry(map[string]*types.Type{
+		"place-order":   {Init: func() any { return &PlaceOrder{} }},
+		"ship-order":    {Init: func() any { return &ShipOrder{} }},
+		"order-placed":  {Init: func() any { return &OrderPlaced{} }},
+		"order-shipped": {Init: func() any { return &OrderShipped{} }},
+	})
+	if err != nil {
+		return err
+	}
+
+	mgr, err := rita.New(nc, rita.WithRegistry(registry))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{Name: "orders"})
+	if err != nil {
+		return err
+	}
+
+	// NewModel wraps the aggregate with thread-safety and per-entity sequence
+	// tracking. DecideAndEvolve decides, appends the events, and applies them
+	// back to the in-memory model in one step.
+	model := rita.NewModel(&Order{})
+
+	if _, _, err := es.DecideAndEvolve(ctx, model, &rita.Command{Data: &PlaceOrder{Amount: 50}}); err != nil {
+		return err
+	}
+	if _, _, err := es.DecideAndEvolve(ctx, model, &rita.Command{Data: &ShipOrder{Carrier: "UPS"}}); err != nil {
+		return err
+	}
+
+	// View reads the model's current state under a read lock.
+	if err := model.View(ctx, func(o *Order) error {
+		fmt.Printf("placed=%v shipped=%v amount=%d\n", o.Placed, o.Shipped, o.Amount)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// A decision that would violate an invariant is refused, and nothing is
+	// appended.
+	if _, _, err := es.DecideAndEvolve(ctx, model, &rita.Command{Data: &ShipOrder{Carrier: "FedEx"}}); err != nil {
+		fmt.Printf("second ship rejected: %v\n", err)
+	}
+
+	return nil
+}

--- a/examples/optimistic-concurrency/main.go
+++ b/examples/optimistic-concurrency/main.go
@@ -1,0 +1,119 @@
+// Optimistic-concurrency demonstrates guarding an append with an expected
+// sequence so a concurrent writer cannot clobber another's change. The losing
+// writer gets ErrSequenceConflict, reloads current state, and retries.
+//
+// Run with: go run ./examples/optimistic-concurrency
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/synadia-labs/rita"
+	"github.com/synadia-labs/rita/testutil"
+	"github.com/synadia-labs/rita/types"
+)
+
+type OrderPlaced struct{ Amount int }
+type OrderShipped struct{ Carrier string }
+type OrderNoteAdded struct{ Note string }
+
+// order counts applied events; its only job here is to surface the entity's
+// last sequence from Evolve.
+type order struct{ events int }
+
+func (o *order) Evolve(_ context.Context, _ *rita.Event) error {
+	o.events++
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	dir, err := os.MkdirTemp("", "rita-example-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	srv := testutil.NewNatsServerWithDir(dir)
+	defer testutil.ShutdownNatsServer(srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	registry, err := types.NewRegistry(map[string]*types.Type{
+		"order-placed":     {Init: func() any { return &OrderPlaced{} }},
+		"order-shipped":    {Init: func() any { return &OrderShipped{} }},
+		"order-note-added": {Init: func() any { return &OrderNoteAdded{} }},
+	})
+	if err != nil {
+		return err
+	}
+
+	mgr, err := rita.New(nc, rita.WithRegistry(registry))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{Name: "orders"})
+	if err != nil {
+		return err
+	}
+
+	// Seed the entity. Expecting sequence 0 asserts the entity is brand new.
+	seq, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderPlaced{Amount: 50}, Expect: rita.ExpectSequence(0)},
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("placed at seq=%d\n", seq)
+
+	// Two writers both observed the entity's last sequence as 1 and each guard
+	// their append with ExpectSequence(1). Only the first can win.
+	const observed = 1
+
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderShipped{Carrier: "UPS"}, Expect: rita.ExpectSequence(observed)},
+	}); err != nil {
+		return err
+	}
+	fmt.Println("writer A: shipped (won)")
+
+	_, err = es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderNoteAdded{Note: "gift wrap"}, Expect: rita.ExpectSequence(observed)},
+	})
+	if !errors.Is(err, rita.ErrSequenceConflict) {
+		return fmt.Errorf("expected sequence conflict, got %v", err)
+	}
+	fmt.Println("writer B: conflict (lost)")
+
+	// Writer B recovers: reload current state to learn the new last sequence,
+	// then retry the append guarded by that sequence.
+	var current order
+	last, err := es.Evolve(ctx, &current, rita.WithFilters("order.1"))
+	if err != nil {
+		return err
+	}
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderNoteAdded{Note: "gift wrap"}, Expect: rita.ExpectSequence(last)},
+	}); err != nil {
+		return err
+	}
+	fmt.Printf("writer B: retried at seq=%d (won)\n", last)
+
+	return nil
+}

--- a/examples/projection/main.go
+++ b/examples/projection/main.go
@@ -113,8 +113,11 @@ func run() error {
 		}); err != nil {
 			return err
 		}
-		if done || time.Now().After(deadline) {
+		if done {
 			break
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("projection did not catch up within deadline")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/examples/projection/main.go
+++ b/examples/projection/main.go
@@ -1,0 +1,126 @@
+// Projection demonstrates Watch: a model kept continuously up to date as events
+// are appended. Because events are applied from a background goroutine, the
+// model must be thread-safe, so it is wrapped with NewModel and read via View.
+//
+// Run with: go run ./examples/projection
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/synadia-labs/rita"
+	"github.com/synadia-labs/rita/testutil"
+	"github.com/synadia-labs/rita/types"
+)
+
+type OrderPlaced struct{ Amount int }
+type OrderShipped struct{ Carrier string }
+
+// Stats is a read model aggregating across all orders.
+type Stats struct {
+	Placed  int
+	Shipped int
+}
+
+func (s *Stats) Evolve(_ context.Context, e *rita.Event) error {
+	switch e.Data.(type) {
+	case *OrderPlaced:
+		s.Placed++
+	case *OrderShipped:
+		s.Shipped++
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	dir, err := os.MkdirTemp("", "rita-example-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	srv := testutil.NewNatsServerWithDir(dir)
+	defer testutil.ShutdownNatsServer(srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	registry, err := types.NewRegistry(map[string]*types.Type{
+		"order-placed":  {Init: func() any { return &OrderPlaced{} }},
+		"order-shipped": {Init: func() any { return &OrderShipped{} }},
+	})
+	if err != nil {
+		return err
+	}
+
+	mgr, err := rita.New(nc, rita.WithRegistry(registry))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{Name: "orders"})
+	if err != nil {
+		return err
+	}
+
+	// Some events already exist before the projection starts.
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderPlaced{Amount: 50}},
+		{Entity: "order.2", Data: &OrderPlaced{Amount: 75}},
+	}); err != nil {
+		return err
+	}
+
+	// Watch catches up on existing events before returning, then keeps applying
+	// new ones in the background until Stop.
+	model := rita.NewModel(&Stats{})
+	w, err := es.Watch(ctx, model)
+	if err != nil {
+		return err
+	}
+	defer w.Stop()
+
+	// Append more events after the watch is live.
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderShipped{Carrier: "UPS"}},
+		{Entity: "order.2", Data: &OrderShipped{Carrier: "FedEx"}},
+	}); err != nil {
+		return err
+	}
+
+	// Delivery is asynchronous, so poll the view until it reflects all events.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var done bool
+		if err := model.View(ctx, func(s *Stats) error {
+			done = s.Placed == 2 && s.Shipped == 2
+			return nil
+		}); err != nil {
+			return err
+		}
+		if done || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return model.View(ctx, func(s *Stats) error {
+		fmt.Printf("placed=%d shipped=%d\n", s.Placed, s.Shipped)
+		return nil
+	})
+}

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -1,0 +1,109 @@
+// Quickstart appends events for an order and rebuilds the order's state by
+// folding those events through a model. It is the example referenced by the
+// project README and docs/.
+//
+// Run with: go run ./examples/quickstart
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/synadia-labs/rita"
+	"github.com/synadia-labs/rita/testutil"
+	"github.com/synadia-labs/rita/types"
+)
+
+// Events are facts that have already happened.
+type OrderPlaced struct {
+	OrderID string
+	Amount  int
+}
+
+type OrderShipped struct {
+	OrderID string
+	Carrier string
+}
+
+// Order is a model. It implements Evolver to fold events into state.
+type Order struct {
+	Placed  bool
+	Shipped bool
+	Amount  int
+}
+
+func (o *Order) Evolve(_ context.Context, e *rita.Event) error {
+	switch d := e.Data.(type) {
+	case *OrderPlaced:
+		o.Placed, o.Amount = true, d.Amount
+	case *OrderShipped:
+		o.Shipped = true
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	// Embedded JetStream server so the example is self-contained.
+	dir, err := os.MkdirTemp("", "rita-example-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	srv := testutil.NewNatsServerWithDir(dir)
+	defer testutil.ShutdownNatsServer(srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	// A registry maps event names to Go types so Rita can (de)serialize them.
+	registry, err := types.NewRegistry(map[string]*types.Type{
+		"order-placed":  {Init: func() any { return &OrderPlaced{} }},
+		"order-shipped": {Init: func() any { return &OrderShipped{} }},
+	})
+	if err != nil {
+		return err
+	}
+
+	mgr, err := rita.New(nc, rita.WithRegistry(registry))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// An event store is backed by a JetStream stream.
+	es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{Name: "orders"})
+	if err != nil {
+		return err
+	}
+
+	// Append events for an entity, identified as "<type>.<id>".
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1001", Data: &OrderPlaced{OrderID: "1001", Amount: 50}},
+		{Entity: "order.1001", Data: &OrderShipped{OrderID: "1001", Carrier: "UPS"}},
+	}); err != nil {
+		return err
+	}
+
+	// Rebuild state by replaying the entity's events through the model.
+	var order Order
+	if _, err := es.Evolve(ctx, &order, rita.WithFilters("order.1001")); err != nil {
+		return err
+	}
+
+	fmt.Printf("placed=%v shipped=%v amount=%d\n", order.Placed, order.Shipped, order.Amount)
+	return nil
+}

--- a/examples/tenancy/main.go
+++ b/examples/tenancy/main.go
@@ -1,0 +1,117 @@
+// Tenancy demonstrates a tenant store: one event store serving many isolated
+// tenants. Every operation goes through a tenant-scoped handle, and each
+// tenant's events occupy a disjoint slice of the subject space.
+//
+// Run with: go run ./examples/tenancy
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/synadia-labs/rita"
+	"github.com/synadia-labs/rita/testutil"
+	"github.com/synadia-labs/rita/types"
+)
+
+type OrderPlaced struct{ Amount int }
+
+// orders counts the events it sees.
+type orders struct{ count int }
+
+func (o *orders) Evolve(_ context.Context, _ *rita.Event) error {
+	o.count++
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	dir, err := os.MkdirTemp("", "rita-example-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	srv := testutil.NewNatsServerWithDir(dir)
+	defer testutil.ShutdownNatsServer(srv)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	registry, err := types.NewRegistry(map[string]*types.Type{
+		"order-placed": {Init: func() any { return &OrderPlaced{} }},
+	})
+	if err != nil {
+		return err
+	}
+
+	mgr, err := rita.New(nc, rita.WithRegistry(registry))
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Tenancy is fixed at creation and recorded in stream metadata.
+	es, err := mgr.CreateEventStore(ctx, rita.EventStoreConfig{Name: "orders", Tenancy: true})
+	if err != nil {
+		return err
+	}
+
+	// The bare handle is unscoped: store operations require a tenant scope.
+	if _, err := es.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderPlaced{Amount: 10}},
+	}); !errors.Is(err, rita.ErrTenantRequired) {
+		return fmt.Errorf("expected ErrTenantRequired, got %v", err)
+	}
+	fmt.Println("unscoped append rejected")
+
+	// Derive a scoped handle per tenant. The receiver is unchanged, so handles
+	// are cheap and immutable.
+	acme, err := es.Tenant("acme")
+	if err != nil {
+		return err
+	}
+	beta, err := es.Tenant("beta")
+	if err != nil {
+		return err
+	}
+
+	if _, err := acme.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderPlaced{Amount: 50}},
+		{Entity: "order.2", Data: &OrderPlaced{Amount: 75}},
+	}); err != nil {
+		return err
+	}
+	if _, err := beta.Append(ctx, []*rita.Event{
+		{Entity: "order.1", Data: &OrderPlaced{Amount: 99}},
+	}); err != nil {
+		return err
+	}
+
+	// Each tenant sees only its own events. A scoped handle with no filters is
+	// confined to its tenant, never the whole stream.
+	var acmeOrders orders
+	if _, err := acme.Evolve(ctx, &acmeOrders); err != nil {
+		return err
+	}
+	var betaOrders orders
+	if _, err := beta.Evolve(ctx, &betaOrders); err != nil {
+		return err
+	}
+
+	fmt.Printf("acme orders=%d beta orders=%d\n", acmeOrders.count, betaOrders.count)
+	return nil
+}


### PR DESCRIPTION
## Summary

Replaces the "coming soon" Getting Started and adds a `docs/` directory that
breaks down each Rita pattern in depth.

- **README** — concept-first intro ("thinking in events") plus a worked
  quickstart excerpt.
- **docs/** — one page per area: event stores, events & types, deciders &
  evolvers, reading state, reactors, and multi-tenancy.
- Docs show only the *meaningful portion* of each pattern and reference a full,
  runnable program by line number.
- **examples/** — one runnable program per pattern (`quickstart`, `deciders`,
  `optimistic-concurrency`, `projection`, `tenancy`) beside the existing reactor
  demos.

## Notes

- Based off `feat/tenant-id-subject` (stacks on #40), since the docs document
  the tenancy feature it introduces. Retarget to `main` once that merges.
- All seven examples build, `vet`, and run; every doc/README example link was
  validated to resolve.
- Caveat: the line-number references are coupled to the example files, so
  editing an example can drift its citations. Each citation names what's at the
  lines (e.g. "`Bind` 102–104") so it stays locatable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)