### PR TITLE
Scope reactor lookups to the calling tenant

### DIFF
--- a/reactor.go
+++ b/reactor.go
@@ -188,10 +188,15 @@ func (s *EventStore) CreateReactor(ctx context.Context, cfg ReactorConfig) (Reac
 // instances do not hot-reload updated settings. Unbind and Bind again to
 // pick up changed runtime retry behavior such as BackOff.
 //
-// Returns ErrReactorNotFound if no durable with this name exists.
+// Returns ErrReactorNotFound if no durable with this name exists, or — on a
+// tenant-scoped handle — if it belongs to another tenant (matching
+// GetReactor's visibility).
 func (s *EventStore) UpdateReactor(ctx context.Context, cfg ReactorConfig) (Reactor, error) {
 	cc, err := s.prepareReactorConfig(cfg)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireReactorScope(ctx, cfg.Name, "update reactor"); err != nil {
 		return nil, err
 	}
 	if _, err := s.js.UpdateConsumer(ctx, s.stream, cc); err != nil {
@@ -203,10 +208,29 @@ func (s *EventStore) UpdateReactor(ctx context.Context, cfg ReactorConfig) (Reac
 // CreateOrUpdateReactor provisions or updates a reactor and returns an
 // unbound Reactor handle. Use this for declarative service-startup hooks
 // where idempotent provisioning is desired regardless of prior config.
+//
+// On a tenant-scoped handle the upsert applies only to the tenant's own
+// durable: a name held by another tenant returns ErrReactorExists rather than
+// overwriting the foreign durable.
 func (s *EventStore) CreateOrUpdateReactor(ctx context.Context, cfg ReactorConfig) (Reactor, error) {
 	cc, err := s.prepareReactorConfig(cfg)
 	if err != nil {
 		return nil, err
+	}
+	// An upsert must not steal a durable belonging to another tenant; the
+	// name reads as taken, matching the create path's conflict signal.
+	if s.tenant != "" {
+		cons, err := s.js.Consumer(ctx, s.stream, cfg.Name)
+		switch {
+		case err == nil:
+			if !s.reactorInTenantScope(cons.CachedInfo().Config.FilterSubjects) {
+				return nil, fmt.Errorf("%w: %s", ErrReactorExists, cfg.Name)
+			}
+		case errors.Is(err, jetstream.ErrConsumerNotFound), errors.Is(err, jetstream.ErrConsumerDoesNotExist):
+			// Absent: proceeds as a create.
+		default:
+			return nil, fmt.Errorf("rita: create-or-update reactor: %w", err)
+		}
 	}
 	if _, err := s.js.CreateOrUpdateConsumer(ctx, s.stream, cc); err != nil {
 		return nil, fmt.Errorf("rita: create-or-update reactor: %w", err)
@@ -221,12 +245,17 @@ func (s *EventStore) CreateOrUpdateReactor(ctx context.Context, cfg ReactorConfi
 // EventStore's logger. The caller is still responsible for calling
 // (Reactor).Unbind to release the runtime handle.
 //
-// Returns ErrReactorNotFound if no reactor with this name exists.
+// Returns ErrReactorNotFound if no reactor with this name exists, or — on a
+// tenant-scoped handle — if it belongs to another tenant (matching
+// GetReactor's visibility).
 func (s *EventStore) DeleteReactor(ctx context.Context, name string) error {
 	if name == "" {
 		return ErrReactorNameRequired
 	}
 	if err := s.requireTenant(); err != nil {
+		return err
+	}
+	if err := s.requireReactorScope(ctx, name, "delete reactor"); err != nil {
 		return err
 	}
 	if err := s.js.DeleteConsumer(ctx, s.stream, name); err != nil {
@@ -321,6 +350,26 @@ func (s *EventStore) reactorInTenantScope(filterSubjects []string) bool {
 		}
 	}
 	return true
+}
+
+// requireReactorScope guards mutations of an existing durable on a
+// tenant-scoped handle. Lookup scoping makes foreign reactors invisible, so
+// without this check a scoped handle could still delete or overwrite a
+// foreign durable by guessing its name. An out-of-scope durable is
+// indistinguishable from an absent one, matching GetReactor. Unscoped handles
+// keep the stream-wide view and skip the check.
+func (s *EventStore) requireReactorScope(ctx context.Context, name, action string) error {
+	if s.tenant == "" {
+		return nil
+	}
+	cons, err := s.js.Consumer(ctx, s.stream, name)
+	if err != nil {
+		return reactorErr(err, action)
+	}
+	if !s.reactorInTenantScope(cons.CachedInfo().Config.FilterSubjects) {
+		return fmt.Errorf("%w: %s", ErrReactorNotFound, name)
+	}
+	return nil
 }
 
 func (s *EventStore) reactorInfoFromJS(info *jetstream.ConsumerInfo) *ReactorInfo {

--- a/reactor.go
+++ b/reactor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -241,19 +242,27 @@ func (s *EventStore) DeleteReactor(ctx context.Context, name string) error {
 // Durable consumers created outside Rita are visible; there is no Rita-specific
 // marker to distinguish them.
 //
-// Tenant scope: lookup is stream-global by durable name and is NOT tenant-filtered,
-// even on a tenant store. The mutating reactor operations (Create/Update/
-// CreateOrUpdate/Delete) require a tenant scope so they build correctly scoped
-// filter subjects, but durable names share a single stream-wide namespace. Callers
-// that need per-tenant reactor isolation should namespace durable names per tenant
-// (e.g. "<tenant>-<name>"); library-side namespacing is a possible future addition.
+// Tenant scope: on a tenant-scoped handle (es.Tenant("acme")) only reactors
+// belonging to that tenant are visible — one whose filter subjects are not
+// confined to the tenant's subject prefix returns ErrReactorNotFound, even if a
+// durable by that name exists for another tenant. An unscoped handle sees every
+// reactor on the stream. Durable names still share one stream-wide namespace, so
+// distinct tenants must still give their reactors distinct names.
 //
-// Returns ErrReactorNotFound if no durable with this name exists.
+// Returns ErrReactorNotFound if no durable with this name exists, or if it exists
+// but falls outside this handle's tenant scope.
 func (s *EventStore) GetReactor(ctx context.Context, name string) (Reactor, error) {
 	if name == "" {
 		return nil, ErrReactorNameRequired
 	}
-	return s.newReactorHandle(ctx, name)
+	handle, err := s.newReactorHandle(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if !s.reactorInTenantScope(handle.cons.CachedInfo().Config.FilterSubjects) {
+		return nil, ErrReactorNotFound
+	}
+	return handle, nil
 }
 
 // ListReactors returns durable consumers on the stream backing this EventStore.
@@ -261,14 +270,14 @@ func (s *EventStore) GetReactor(ctx context.Context, name string) (Reactor, erro
 // are excluded. Durable consumers created outside Rita are included: the filter
 // is on whether the consumer has a Durable name, not on any Rita-specific marker.
 //
-// Tenant scope: listing is stream-global and is NOT filtered to the calling
-// handle's tenant. On a tenant store the result includes durables created under
-// every tenant. Each ReactorInfo.Config.Filters is decoded by stripping the
-// calling handle's tenant prefix, so the format is mixed within a single call:
-// a durable belonging to the calling tenant comes back in user form
-// ("*.*.order-shipped"), while a durable from another tenant does not match the
-// prefix and is surfaced verbatim ("$ES.<name>.<other-tenant>.*.*.order-shipped").
-// See GetReactor for the rationale and the caller's namespacing responsibility.
+// Tenant scope: on a tenant-scoped handle (es.Tenant("acme")) the result is
+// limited to reactors belonging to that tenant — those whose filter subjects are
+// confined to the tenant's subject prefix. Their ReactorInfo.Config.Filters come
+// back in user form ("*.*.order-shipped") with the tenant prefix stripped. An
+// unscoped handle lists every durable on the stream across all tenants. Reactors
+// with no filters or filters spanning more than one tenant (e.g. consumers
+// created outside Rita) are not claimed by any tenant and appear only in the
+// unscoped listing.
 func (s *EventStore) ListReactors(ctx context.Context) ([]*ReactorInfo, error) {
 	stream, err := s.js.Stream(ctx, s.stream)
 	if err != nil {
@@ -280,12 +289,38 @@ func (s *EventStore) ListReactors(ctx context.Context) ([]*ReactorInfo, error) {
 		if info.Config.Durable == "" {
 			continue
 		}
+		if !s.reactorInTenantScope(info.Config.FilterSubjects) {
+			continue
+		}
 		out = append(out, s.reactorInfoFromJS(info))
 	}
 	if err := lister.Err(); err != nil {
 		return nil, fmt.Errorf("rita: list reactors: %w", err)
 	}
 	return out, nil
+}
+
+// reactorInTenantScope reports whether a durable with the given filter subjects
+// belongs to this handle's tenant. An unscoped handle (s.tenant == "") scopes
+// nothing and sees every reactor. On a tenant-scoped handle a reactor is in scope
+// only when all of its filter subjects sit under the tenant's subject prefix —
+// exactly how Create/Update build them. A reactor with no filters, or filters
+// spanning another tenant (e.g. a consumer created outside Rita), is not claimed
+// by any tenant and is visible only through an unscoped handle.
+func (s *EventStore) reactorInTenantScope(filterSubjects []string) bool {
+	if s.tenant == "" {
+		return true
+	}
+	if len(filterSubjects) == 0 {
+		return false
+	}
+	prefix := s.subjectPrefix("")
+	for _, fs := range filterSubjects {
+		if !strings.HasPrefix(fs, prefix) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *EventStore) reactorInfoFromJS(info *jetstream.ConsumerInfo) *ReactorInfo {

--- a/tenant_test.go
+++ b/tenant_test.go
@@ -315,3 +315,49 @@ func reactorNames(rs []*ReactorInfo) []string {
 	}
 	return names
 }
+
+// TestTenantReactorMutationScoped pins write-side isolation: lookup scoping
+// makes foreign reactors invisible, so mutations must refuse them too —
+// otherwise a scoped handle could delete or overwrite a durable it cannot even
+// see, by guessing its name. Delete/Update surface the foreign durable as
+// absent (matching GetReactor); the upsert surfaces the name as taken rather
+// than silently rewriting the foreign durable's filters to its own tenant.
+func TestTenantReactorMutationScoped(t *testing.T) {
+	is := testutil.NewIs(t)
+	m, ctx := newTestManager(t)
+
+	es, err := m.CreateEventStore(ctx, EventStoreConfig{Name: "rmut", Tenancy: true})
+	is.NoErr(err)
+
+	acme, err := es.Tenant("acme")
+	is.NoErr(err)
+	beta, err := es.Tenant("beta")
+	is.NoErr(err)
+
+	_, err = beta.CreateReactor(ctx, ReactorConfig{Name: "beta-shipper", Filters: []string{"*.*.order-shipped"}})
+	is.NoErr(err)
+
+	// A foreign durable cannot be deleted or updated; it reads as absent.
+	err = acme.DeleteReactor(ctx, "beta-shipper")
+	is.Err(err, ErrReactorNotFound)
+
+	_, err = acme.UpdateReactor(ctx, ReactorConfig{Name: "beta-shipper", Filters: []string{"*.*.order-placed"}})
+	is.Err(err, ErrReactorNotFound)
+
+	// An upsert cannot steal it either; the name reads as taken.
+	_, err = acme.CreateOrUpdateReactor(ctx, ReactorConfig{Name: "beta-shipper", Filters: []string{"*.*.order-placed"}})
+	is.Err(err, ErrReactorExists)
+
+	// The foreign durable is untouched: still beta's, with its original filter.
+	r, err := beta.GetReactor(ctx, "beta-shipper")
+	is.NoErr(err)
+	info, err := r.Info(ctx)
+	is.NoErr(err)
+	is.Equal(info.Config.Filters, []string{"*.*.order-shipped"})
+
+	// The owner retains full mutation rights.
+	_, err = beta.CreateOrUpdateReactor(ctx, ReactorConfig{Name: "beta-shipper", Filters: []string{"*.*.order-returned"}})
+	is.NoErr(err)
+	err = beta.DeleteReactor(ctx, "beta-shipper")
+	is.NoErr(err)
+}

--- a/tenant_test.go
+++ b/tenant_test.go
@@ -1,6 +1,7 @@
 package rita
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/synadia-labs/rita/testutil"
@@ -256,4 +257,61 @@ func TestTenantReactorRoundTrip(t *testing.T) {
 	// A scoped handle can delete its reactor.
 	err = acme.DeleteReactor(ctx, "shipper")
 	is.NoErr(err)
+}
+
+// TestTenantReactorLookupScoped verifies that reactor lookups are tenant-scoped:
+// a scoped handle sees only its own reactors and cannot fetch another tenant's,
+// while the unscoped handle sees every reactor across tenants. This is the
+// isolation that lets each tenant manage its reactors without observing or
+// fetching durables belonging to other tenants.
+func TestTenantReactorLookupScoped(t *testing.T) {
+	is := testutil.NewIs(t)
+	m, ctx := newTestManager(t)
+
+	es, err := m.CreateEventStore(ctx, EventStoreConfig{Name: "rlookup", Tenancy: true})
+	is.NoErr(err)
+
+	acme, err := es.Tenant("acme")
+	is.NoErr(err)
+	beta, err := es.Tenant("beta")
+	is.NoErr(err)
+
+	_, err = acme.CreateReactor(ctx, ReactorConfig{Name: "acme-shipper", Filters: []string{"*.*.order-shipped"}})
+	is.NoErr(err)
+	_, err = beta.CreateReactor(ctx, ReactorConfig{Name: "beta-shipper", Filters: []string{"*.*.order-shipped"}})
+	is.NoErr(err)
+
+	// Each scoped handle lists only its own reactor.
+	acmeList, err := acme.ListReactors(ctx)
+	is.NoErr(err)
+	is.Equal(reactorNames(acmeList), []string{"acme-shipper"})
+
+	betaList, err := beta.ListReactors(ctx)
+	is.NoErr(err)
+	is.Equal(reactorNames(betaList), []string{"beta-shipper"})
+
+	// The unscoped handle sees both, across tenants.
+	allList, err := es.ListReactors(ctx)
+	is.NoErr(err)
+	names := reactorNames(allList)
+	sort.Strings(names)
+	is.Equal(names, []string{"acme-shipper", "beta-shipper"})
+
+	// GetReactor is invisible across tenants, but works within scope and unscoped.
+	_, err = acme.GetReactor(ctx, "beta-shipper")
+	is.Err(err, ErrReactorNotFound)
+
+	_, err = acme.GetReactor(ctx, "acme-shipper")
+	is.NoErr(err)
+
+	_, err = es.GetReactor(ctx, "beta-shipper")
+	is.NoErr(err)
+}
+
+func reactorNames(rs []*ReactorInfo) []string {
+	names := make([]string, len(rs))
+	for i, r := range rs {
+		names[i] = r.Name
+	}
+	return names
 }


### PR DESCRIPTION
## Summary

On a tenant store, `GetReactor` and `ListReactors` ignored the handle's tenant
and returned reactors across all tenants — inconsistent with the subject-level
isolation enforced everywhere else on a tenant store. This scopes both lookups
to the calling handle's tenant.

- A tenant-scoped handle (`es.Tenant("acme")`) now lists only its own reactors,
  and `GetReactor` returns `ErrReactorNotFound` for another tenant's durable.
- An unscoped handle keeps the full cross-tenant view.
- Membership is determined by the tenant subject prefix already present in each
  durable's `FilterSubjects` (exactly how Create/Update build them). A reactor
  with no filters, or filters spanning more than one tenant (e.g. a consumer
  created outside Rita), is claimed by no tenant and appears only in the
  unscoped listing.
- Durable names remain a single stream-wide namespace, so tenants must still
  name reactors distinctly. Mutations and the untenanted path are unchanged.

Addresses @bruth's review comment on #41:
https://github.com/synadia-labs/rita/pull/41#discussion_r3498735790

## Tests

Adds `TestTenantReactorLookupScoped`: two tenants each create a reactor, then
asserts each scoped handle lists only its own, the unscoped handle lists both,
and a cross-tenant `GetReactor` returns `ErrReactorNotFound`.

## Follow-up

PR #41's `docs/tenancy.md` and the `reactor.go` godoc currently describe the
prior "lookups are not tenant-filtered" behavior; #41's docs will be updated to
match once this merges.
